### PR TITLE
process case of empty changes

### DIFF
--- a/src/changes/index.js
+++ b/src/changes/index.js
@@ -33,6 +33,9 @@ export default class Changes {
         let result = this.httpClient.readJSON(changesListUrl(buildId));
         if (options.withDetails) {
             result = result.then(changes => {
+                if (!Array.isArray(changes.change)) {
+                    return changes;
+                }
                 const tasks = changes.change.map(change => {
                     return this.detail(change.id).catch(() => change);
                 });

--- a/test/changes/index.test.js
+++ b/test/changes/index.test.js
@@ -50,6 +50,18 @@ describe('changes/index', function () {
         });
     });
 
+    it('should load list with details in case of no changes', function () {
+        nock.cleanAll();
+        nock(`http://${tcHost}`)
+            .get('/guestAuth/app/rest/changes/')
+            .query({build: 'id:123'})
+            .reply(200, {id: 123});
+
+        return this.changes.list(123, {withDetails: true}).then(changes => {
+            assert.deepEqual(changes, {id: 123});
+        });
+    });
+
     it('should load details', function () {
         return this.changes.detail(1).then(change => {
             assert.deepEqual(change, {id: 1, comment: 'abc'});


### PR DESCRIPTION
When build has no changes teamcity returns undefined instead of empty `change` array.

@acvetkov 
