### PR TITLE
Fix 21

### DIFF
--- a/src/build/index.js
+++ b/src/build/index.js
@@ -18,18 +18,20 @@ export default class Build {
     /**
      * Get last build by query
      * @param {Object|String|Number} locator
+     * @param {Object} args API http query arguments
      * @returns {Promise.<Object>|*}
      */
-    detail (locator) {
-        return this.httpClient.readJSON(buildDetailUrl(locator));
+    detail (locator, args) {
+        return this.httpClient.readJSON(buildDetailUrl(locator, args));
     }
 
     /**
      * Get build list by query
      * @param {Object|String|Number} locator
+     * @param {Object} args API http query arguments
      * @returns {Promise.<Object>}
      */
-    list (locator) {
-        return this.httpClient.readJSON(buildListUrl(locator));
+    list (locator, args) {
+        return this.httpClient.readJSON(buildListUrl(locator, args));
     }
 }

--- a/src/build/url.js
+++ b/src/build/url.js
@@ -3,34 +3,47 @@
  * @overview build urls helper
  */
 
-import {locatorToString} from '../utils/url';
+import {locatorToString, serializeParams} from '../utils/url';
 
 /**
  * Get detail build url
  * @see https://confluence.jetbrains.com/display/TCD9/REST+API#RESTAPI-BuildLocator
  * @param {Object|String|Number} locatorObject
+ * @param {Object} args API http query arguments
  * @returns {String}
  * @throws {Error} Argument locatorObject must not be empty
  */
-export function buildDetailUrl(locatorObject = {}) {
+export function buildDetailUrl(locatorObject = {}, args = undefined) {
     const locator = locatorToString(locatorObject);
     if (!locator) {
         throw new Error('Please fill locatorObject');
     }
-    return `builds/${locator}`;
+
+    let rv = `builds/${locator}`;
+    if (args) {
+        const args_s = serializeParams(args);
+        rv += `?${args_s}`;
+    }
+    return rv;
 }
 
 /**
  * Get list build url
  * @see https://confluence.jetbrains.com/display/TCD9/REST+API#RESTAPI-BuildLocator
  * @param {Object|String|Number|undefined} locatorObject
+ * @param {Object} args API http query arguments
  * @returns {String}
  */
-export function buildListUrl(locatorObject = {}) {
+export function buildListUrl(locatorObject = {}, args = undefined) {
     let rv = 'builds/' ;
     const locator = locatorToString(locatorObject);
     if (locator) {
         rv += `?locator=${locator}`;
+    }
+    if (args) {
+        const args_s = serializeParams(args);
+        rv += locator ? '&' : '?';
+        rv += args_s;
     }
     return rv;
 }

--- a/src/build/url.js
+++ b/src/build/url.js
@@ -10,19 +10,27 @@ import {locatorToString} from '../utils/url';
  * @see https://confluence.jetbrains.com/display/TCD9/REST+API#RESTAPI-BuildLocator
  * @param {Object|String|Number} locatorObject
  * @returns {String}
+ * @throws {Error} Argument locatorObject must not be empty
  */
 export function buildDetailUrl(locatorObject = {}) {
     const locator = locatorToString(locatorObject);
+    if (!locator) {
+        throw new Error('Please fill locatorObject');
+    }
     return `builds/${locator}`;
 }
 
 /**
  * Get list build url
  * @see https://confluence.jetbrains.com/display/TCD9/REST+API#RESTAPI-BuildLocator
- * @param {Object|String|Number} locatorObject
+ * @param {Object|String|Number|undefined} locatorObject
  * @returns {String}
  */
 export function buildListUrl(locatorObject = {}) {
+    let rv = 'builds/' ;
     const locator = locatorToString(locatorObject);
-    return `builds/?locator=${locator}`;
+    if (locator) {
+        rv += `?locator=${locator}`;
+    }
+    return rv;
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -35,5 +35,5 @@ export function locatorToString(data) {
  * @returns {String}
  */
 export function serializeParams(data) {
-    return _.map(data, (val, key) => `${key}=${val}`).join('&');
+    return _.map(data, (val, key) => `${encodeURIComponent(key)}=${encodeURIComponent(val)}`).join('&');
 }

--- a/test/build/url.test.js
+++ b/test/build/url.test.js
@@ -7,7 +7,7 @@ import {buildDetailUrl, buildListUrl} from '../../src/build/url';
 describe('buildDetailUrl', function () {
 
     it('should throw Error when locator is empty', function () {
-        //NOTE: this because 'builds/' API return list, not details
+        // NOTE: this because 'builds/' API return list, not details
         assert.throws(() => buildDetailUrl({}), Error);
         assert.throws(() => buildDetailUrl(), Error);
     });
@@ -73,7 +73,9 @@ describe('buildListUrl', function () {
     });
 
     it('should return list apiPath for build id limited by count in query args', function () {
-        assert.equal(buildListUrl({buildType: {id: 'my-build-id'}}, {count: 42}), 'builds/?locator=buildType:(id:my-build-id)&count=42');
+        assert.equal(buildListUrl({buildType: {id: 'my-build-id'}},
+                                  {count: 42}),
+                                  'builds/?locator=buildType:(id:my-build-id)&count=42');
     });
 
     it('should return list apiPath limited by count in query args', function () {

--- a/test/build/url.test.js
+++ b/test/build/url.test.js
@@ -49,6 +49,10 @@ describe('buildDetailUrl', function () {
             'builds/buildType:(id:mega%2Fproject),tags:(tag%2F1,tag%2F2)'
         );
     });
+
+    it('should return detail apiPath for build id with custom query arg', function () {
+        assert.equal(buildDetailUrl({id: '1'}, {someQueryArg: 42}), 'builds/id:1?someQueryArg=42');
+    });
 });
 
 describe('buildListUrl', function () {
@@ -66,5 +70,13 @@ describe('buildListUrl', function () {
         assert.equal(buildListUrl({buildType: {id: 'my-build-id'}, tags: ['production']}),
             'builds/?locator=buildType:(id:my-build-id),tags:(production)'
         );
+    });
+
+    it('should return list apiPath for build id limited by count in query args', function () {
+        assert.equal(buildListUrl({buildType: {id: 'my-build-id'}}, {count: 42}), 'builds/?locator=buildType:(id:my-build-id)&count=42');
+    });
+
+    it('should return list apiPath limited by count in query args', function () {
+        assert.equal(buildListUrl(undefined, {count: 42}), 'builds/?count=42');
     });
 });

--- a/test/build/url.test.js
+++ b/test/build/url.test.js
@@ -6,9 +6,10 @@ import {buildDetailUrl, buildListUrl} from '../../src/build/url';
 
 describe('buildDetailUrl', function () {
 
-    it('should return apiPath without locator', function () {
-        assert.equal(buildDetailUrl({}), 'builds/');
-        assert.equal(buildDetailUrl(), 'builds/');
+    it('should throw Error when locator is empty', function () {
+        //NOTE: this because 'builds/' API return list, not details
+        assert.throws(() => buildDetailUrl({}), Error);
+        assert.throws(() => buildDetailUrl(), Error);
     });
 
     it('should return detail apiPath for build id', function () {
@@ -52,9 +53,9 @@ describe('buildDetailUrl', function () {
 
 describe('buildListUrl', function () {
 
-    it('should return empty locator', function () {
-        assert.equal(buildListUrl({}), 'builds/?locator=');
-        assert.equal(buildListUrl(), 'builds/?locator=');
+    it('shouldnt return empty locator', function () {
+        assert.equal(buildListUrl({}), 'builds/');
+        assert.equal(buildListUrl(), 'builds/');
     });
 
     it('should return list apiPath for build id', function () {


### PR DESCRIPTION
- review `detail` api - throw exception when locator is empty, because empty locator means `list` api;
- review `list` api - remove `locator` arg from produced api query string when locator is empty, because TC10+ return 400 BadRequest when locator arg is empty;
- fix #21 .