### PR TITLE
Infrastructure upgrades

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [ "env" ],
+  "plugins": [ "transform-object-rest-spread" ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [ "env" ],
-  "plugins": [ "transform-object-rest-spread" ]
+  "presets": [ "@babel/preset-env" ],
+  "plugins": [ "@babel/plugin-proposal-object-rest-spread" ]
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "preset": "yandex",
-  "esnext": true
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 4
+  - 6
+  - 10
 install: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
   - 10
 install: npm install

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "mocha --recursive --compilers js:babel/register --require ./test/setup.js",
-    "code": "eslint ./src ./test && jscs ./src ./test --verbose",
+    "code": "eslint ./src ./test",
     "build": "npm run code && npm run test && npm run babel",
     "babel": "npm run clean && babel ./src --out-dir ./out",
     "clean": "rm -rf ./out/",
@@ -38,7 +38,6 @@
     "chai-as-promised": "^5.1.0",
     "eslint": "^2.7.0",
     "eslint-plugin-babel": "^3.2.0",
-    "jscs": "^2.6.0",
     "mocha": "^2.3.4",
     "nock": "^8.0.0",
     "sinon": "^1.17.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:acvetkov/teamcity-client.git"
   },
   "scripts": {
-    "test": "mocha --recursive --compilers js:babel/register --require ./test/setup.js",
+    "test": "mocha --recursive --require babel-core/register --require ./test/setup.js",
     "code": "eslint ./src ./test",
     "build": "npm run code && npm run test && npm run babel",
     "babel": "npm run clean && babel ./src --out-dir ./out",
@@ -31,8 +31,11 @@
     "q": "^1.5.1"
   },
   "devDependencies": {
-    "babel": "^5.8.34",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:acvetkov/teamcity-client.git"
   },
   "scripts": {
-    "test": "mocha --recursive --require babel-core/register --require ./test/setup.js",
+    "test": "mocha --recursive --require @babel/register --require ./test/setup.js",
     "code": "eslint ./src ./test",
     "build": "npm run code && npm run test && npm run babel",
     "babel": "npm run clean && babel ./src --out-dir ./out",
@@ -31,11 +31,12 @@
     "q": "^1.5.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
+    "@babel/cli": "^7.1.5",
+    "@babel/core": "^7.1.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/preset-env": "^7.1.6",
+    "@babel/register": "^7.0.0",
     "babel-eslint": "^10.0.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -25,21 +25,20 @@
   "author": "Aleksey Tsvetkov <aleksey.dmitrich@gmail.com> (https://github.com/acvetkov)",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.17.1",
-    "debug": "^2.2.0",
-    "lodash": "^3.10.1",
-    "q": "^1.4.1",
-    "q-io": "^1.13.1"
+    "axios": "^0.18.0",
+    "debug": "^4.1.0",
+    "lodash": "^4.17.11",
+    "q": "^1.5.1"
   },
   "devDependencies": {
     "babel": "^5.8.34",
-    "babel-eslint": "^6.0.2",
-    "chai": "^3.4.1",
-    "chai-as-promised": "^5.1.0",
-    "eslint": "^2.7.0",
-    "eslint-plugin-babel": "^3.2.0",
-    "mocha": "^2.3.4",
-    "nock": "^8.0.0",
-    "sinon": "^1.17.2"
+    "babel-eslint": "^10.0.1",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^5.9.0",
+    "eslint-plugin-babel": "^5.3.0",
+    "mocha": "^5.2.0",
+    "nock": "^10.0.2",
+    "sinon": "^7.1.1"
   }
 }


### PR DESCRIPTION
I have made a few changes to infra/toolchain to fix potential security issues and generally clean house.

* JSCS is [now part of ESLint](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2), so it has been removed
* `q-io` was still a dependency in the `package.json` despite having been orphaned by [this change](https://github.com/acvetkov/teamcity-client/pull/20), so that was also removed
* All other dependencies have been updated to their latest versions
* Babel is now v7, using the `env` preset.
* Changed the mocha option `--compilers` to `--require` because [of this deprecation](https://github.com/mochajs/mocha/wiki/compilers-deprecation).

*EDIT*: I have also changed the tested node versions in `.travis.yml` to 6, 8, and 10 per [this release list](https://github.com/nodejs/Release#release-schedule)

The project builds and the test suite runs successfully. I have smoke tested it with some simple queries against a single server and it seems to work fine. Let me know if there is anything you would like addressed in these changes. Thank you for developing this project!